### PR TITLE
REG-22126 fix standalone docker port mapping to match :latest image

### DIFF
--- a/standalone/docker-compose-azure-sql-edge.yml
+++ b/standalone/docker-compose-azure-sql-edge.yml
@@ -23,7 +23,7 @@ services:
     networks:
       - atlas_net
     ports:
-      - "80:8080"
+      - "80:80"
     volumes:
       - atlasvolume:/atlas/files
     env_file:

--- a/standalone/docker-compose.yml
+++ b/standalone/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     networks:
       - atlas_net
     ports:
-      - "80:8080"
+      - "80:80"
     volumes:
       - atlasvolume:/atlas/files
     env_file:


### PR DESCRIPTION
## Summary

Fixes [REG-22126](https://regscale.atlassian.net/browse/REG-22126): after a fresh `standalone_regscale.py` install, the UI is unreachable on `http://localhost`. Reported and verified end-to-end by Jim Townsend.

Root cause: the public `regscale/regscale:latest` image was rebuilt on 2026-05-05 and now sets `ASPNETCORE_URLS=http://+:80`, so the container listens on **port 80**. The standalone compose files were still mapping `"80:8080"` from a prior era when the image listened on 8080, leaving nothing on port 80 inside the container to answer the host port 80 traffic.

## Changes

- `standalone/docker-compose.yml`: `"80:8080"` -> `"80:80"`
- `standalone/docker-compose-azure-sql-edge.yml`: same fix (uses the same `regscale/regscale:latest` image)

## Not in this PR (intentionally)

- `standalone/atlas-deploy.yaml` (k8s manifest) still has `containerPort: 8080`, but it references `c2labs/atlasity:latest`, which is a different image on a different release cadence than `regscale/regscale:latest`. I haven't verified what port that image listens on today, so I'm leaving it alone for this PR. If it's still in use, it should be verified and updated in a follow-up; if it's stale legacy, it can be cleaned up.
- A latent fragility remains: the standalone has no signal when the upstream image's listener port changes. The longer-term fix is in `regscale/Dockerfile` -- pin the listener port explicitly (already done via `ASPNETCORE_URLS=http://+:80`) and ensure all build variants stay consistent, so this drift doesn't recur silently.

## Test plan

- [x] Verified empirically by Jim Townsend: after `standalone_regscale.py setup`, changing this exact mapping from `80:8080` to `80:80` restored access to the UI on `http://localhost`, allowed admin authentication, and completed initial platform configuration.
- [x] Confirmed via `docker image inspect regscale/regscale:latest` that the current image sets `ASPNETCORE_URLS=http://+:80` (listener port 80).
- [ ] Re-verify after merge: fresh `standalone_regscale.py setup` against the merged main produces a reachable UI without manual edits.

[REG-22126]: https://regscale.atlassian.net/browse/REG-22126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ